### PR TITLE
Release v3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-**Description looked better in my notepad. Improvements to readability to come soon.**
 ## Feature Highlights
 * Allows setting stack sizes for nearly every item in Rust.
 * Items are catagorized and automatically populated in the data file.

--- a/README.md
+++ b/README.md
@@ -87,32 +87,53 @@
   "RevertStackSizesToVanillaOnUnload": true,
   "AllowStackingItemsWithDurability": true,
   "HidePrefixWithPluginNameInMessages": false,
-  "GlobalStackMultiplier": 1,
+  "DisableDupeFixAndLeaveWeaponMagsAlone": false,
+  "GlobalStackMultiplier": 1.0,
   "CategoryStackMultipliers": {
-    "Weapon": 1,
-    "Construction": 1,
-    "Items": 1,
-    "Resources": 1,
-    "Attire": 1,
-    "Tool": 1,
-    "Medical": 1,
-    "Food": 1,
-    "Ammunition": 1,
-    "Traps": 1,
-    "Misc": 1,
-    "All": 1,
-    "Common": 1,
-    "Component": 1,
-    "Search": 1,
-    "Favourite": 1,
-    "Electrical": 1,
-    "Fun": 1
+    "Weapon": 1.0,
+    "Construction": 1.0,
+    "Items": 1.0,
+    "Resources": 1.0,
+    "Attire": 1.0,
+    "Tool": 1.0,
+    "Medical": 1.0,
+    "Food": 1.0,
+    "Ammunition": 1.0,
+    "Traps": 1.0,
+    "Misc": 1.0,
+    "All": 1.0,
+    "Common": 1.0,
+    "Component": 1.0,
+    "Search": 1.0,
+    "Favourite": 1.0,
+    "Electrical": 1.0,
+    "Fun": 1.0
   },
   "IndividualItemStackMultipliers": {},
+  "CategoryStackHardLimits": {
+    "Weapon": 0,
+    "Construction": 0,
+    "Items": 0,
+    "Resources": 0,
+    "Attire": 0,
+    "Tool": 0,
+    "Medical": 0,
+    "Food": 0,
+    "Ammunition": 0,
+    "Traps": 0,
+    "Misc": 0,
+    "All": 0,
+    "Common": 0,
+    "Component": 0,
+    "Search": 0,
+    "Favourite": 0,
+    "Electrical": 0,
+    "Fun": 0
+  },
   "IndividualItemStackHardLimits": {},
   "VersionNumber": {
     "Major": 3,
-    "Minor": 0,
+    "Minor": 2,
     "Patch": 0
   }
 }
@@ -124,36 +145,57 @@
   "RevertStackSizesToVanillaOnUnload": true,
   "AllowStackingItemsWithDurability": true,
   "HidePrefixWithPluginNameInMessages": false,
+  "DisableDupeFixAndLeaveWeaponMagsAlone": false,
   "GlobalStackMultiplier": 1,
   "CategoryStackMultipliers": {
-    "Weapon": 1,
-    "Construction": 1,
-    "Items": 5,
-    "Resources": 12,
-    "Attire": 1,
-    "Tool": 1,
-    "Medical": 1,
-    "Food": 1,
-    "Ammunition": 1,
-    "Traps": 1,
-    "Misc": 1,
-    "All": 1,
-    "Common": 1,
-    "Component": 1,
-    "Search": 1,
-    "Favourite": 1,
-    "Electrical": 1,
-    "Fun": 1
+    "Weapon": 10.0,
+    "Construction": 1.0,
+    "Items": 1.0,
+    "Resources": 1.0,
+    "Attire": 1.0,
+    "Tool": 1.0,
+    "Medical": 1.0,
+    "Food": 1.0,
+    "Ammunition": 1.0,
+    "Traps": 1.0,
+    "Misc": 1.0,
+    "All": 1.0,
+    "Common": 1.0,
+    "Component": 1.0,
+    "Search": 1.0,
+    "Favourite": 1.0,
+    "Electrical": 1.0,
+    "Fun": 1.0
   },
   "IndividualItemStackMultipliers": {
     "-566907190": 10
+  },
+  "CategoryStackHardLimits": {
+    "Weapon": 1,
+    "Construction": 0,
+    "Items": 0,
+    "Resources": 50000,
+    "Attire": 0,
+    "Tool": 0,
+    "Medical": 15,
+    "Food": 0,
+    "Ammunition": 0,
+    "Traps": 0,
+    "Misc": 0,
+    "All": 0,
+    "Common": 0,
+    "Component": 0,
+    "Search": 0,
+    "Favourite": 0,
+    "Electrical": 0,
+    "Fun": 0
   },
   "IndividualItemStackHardLimits": {
     "-586342290": 3
   },
   "VersionNumber": {
     "Major": 3,
-    "Minor": 0,
+    "Minor": 2,
     "Patch": 0
   }
 }
@@ -162,9 +204,11 @@
 - `RevertStackSizesToVanillaOnUnload` - If true; item stacksizes are returned to vanilla defaults on plugin unload.
 - `AllowStackingItemsWithDurability` - If enabled, items with durability such as weapons can be stacked if they are at full durability. If disabled items with durability can't be stacked at all. (Contents, attachments and ammo are all returned to the player)
 - `HidePrefixWithPluginNameInMessages` - Currently does nothing. Future version will hide the prefix from chat messages in-game.
+- `DisableDupeFixAndLeaveWeaponMagsAlone` - Disables the dupe fix, which removes ammo from weapons when stacking, with this disabled players can dupe any ammo slowly. 
 - `GlobalStackMultiplier` - Multiplies all item stacks by this value.
 - `CategoryStackMultipliers` - Each category will multiply stacks for those items by the defined amount.
 - `IndividualItemStackMultipliers` - Accepts "item_id": multiplier. Use stacksizecontroller.itemsearch to find the item id easily.
+- `CategoryStackHardLimits` - Each item in this category will be set to this hard stack limit, if the value is above 0.
 - `IndividualItemStackHardLimits` - Accepts "item_id": hard limit. Use stacksizecontroller.itemsearch to find the item id easily.
 
 ## Data

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -127,6 +127,7 @@ namespace Oxide.Plugins
             public bool RevertStackSizesToVanillaOnUnload = true;
             public bool AllowStackingItemsWithDurability = true;
             public bool HidePrefixWithPluginNameInMessages;
+            public bool DisableDupeFixAndLeaveWeaponMagsAlone;
 
             public float GlobalStackMultiplier = 1;
             public Dictionary<string, float> CategoryStackMultipliers = GetCategoriesAndDefaults(1)
@@ -174,6 +175,11 @@ namespace Oxide.Plugins
             if (_config.HidePrefixWithPluginNameInMessages.IsNull<bool>())
             {
                 _config.HidePrefixWithPluginNameInMessages = configDefault.HidePrefixWithPluginNameInMessages;
+            }
+
+            if (_config.DisableDupeFixAndLeaveWeaponMagsAlone.IsNull<bool>())
+            {
+                _config.DisableDupeFixAndLeaveWeaponMagsAlone = configDefault.DisableDupeFixAndLeaveWeaponMagsAlone;
             }
             
             if (_config.GlobalStackMultiplier.IsNull<bool>())
@@ -646,6 +652,11 @@ namespace Oxide.Plugins
                 }
             }
 
+            if (_config.DisableDupeFixAndLeaveWeaponMagsAlone)
+            {
+                return null;
+            }
+                
             BaseProjectile.Magazine itemMag = 
                 targetItem.GetHeldEntity()?.GetComponent<BaseProjectile>()?.primaryMagazine;
             
@@ -703,6 +714,11 @@ namespace Oxide.Plugins
             if (item.IsBlueprint())
             {
                 newItem.blueprintTarget = item.blueprintTarget;
+            }
+            
+            if (_config.DisableDupeFixAndLeaveWeaponMagsAlone)
+            {
+                return newItem;
             }
             
             BaseProjectile.Magazine newItemMag =

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -502,7 +502,7 @@ namespace Oxide.Plugins
                 return;
             }
 
-            UpdateIndividualItemHardLimit(itemDefinition.itemid, Convert.ToInt32(stackSizeString.TrimEnd('x')));
+            UpdateIndividualItemHardLimit(itemDefinition.shortname, Convert.ToInt32(stackSizeString.TrimEnd('x')));
             SetStackSizes();
             player.Reply(GetMessage("OperationSuccessful", player.Id));
         }
@@ -777,6 +777,11 @@ namespace Oxide.Plugins
                 customStackInfo = AddItemToIndex(itemDefinition.itemid);
             }
 
+            if (_ignoreList.Contains(itemDefinition.shortname))
+            {
+                return GetVanillaStackSize(itemDefinition);
+            }
+
             // Individual Limit set by shortname
             if (_config.IndividualItemStackHardLimits.ContainsKey(itemDefinition.shortname))
             {
@@ -806,6 +811,13 @@ namespace Oxide.Plugins
             if (_config.IndividualItemStackMultipliers.ContainsKey(itemDefinition.itemid.ToString()))
             {
                 return Mathf.RoundToInt(stackable * _config.IndividualItemStackMultipliers[itemDefinition.itemid.ToString()]);
+            }
+            
+            // Category stack limit defined
+            if (_config.CategoryStackHardLimits.ContainsKey(itemDefinition.category.ToString()) &&
+                _config.CategoryStackHardLimits[itemDefinition.category.ToString()] > 0)
+            {
+                return _config.CategoryStackHardLimits[itemDefinition.category.ToString()];
             }
 
             // Category stack multiplier defined

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -134,7 +134,7 @@ namespace Oxide.Plugins
             public bool AllowStackingItemsWithDurability = true;
             public bool HidePrefixWithPluginNameInMessages;
 
-            public int GlobalStackMultiplier = 1;
+            public float GlobalStackMultiplier = 1;
             public Dictionary<string, float> CategoryStackMultipliers = GetCategoriesAndDefaults();
             public Dictionary<int, float> IndividualItemStackMultipliers = new Dictionary<int, float>();
             public Dictionary<int, int> IndividualItemStackHardLimits = new Dictionary<int, int>();
@@ -506,7 +506,7 @@ namespace Oxide.Plugins
                 
                 output.AddRow(itemDefinition.itemid.ToString(), itemDefinition.shortname, 
                     itemDefinition.category.ToString(), itemInfo.VanillaStackSize.ToString("N0"), 
-                    itemInfo.CustomStackSize.ToString("N0"));
+                    GetStackSize(itemDefinition).ToString("N0"));
             }
             
             player.Reply(output.ToString());
@@ -549,7 +549,7 @@ namespace Oxide.Plugins
                 
                 output.AddRow(itemDefinition.itemid.ToString(), itemDefinition.shortname, 
                     itemDefinition.category.ToString(), itemInfo.VanillaStackSize.ToString("N0"), 
-                    itemInfo.CustomStackSize.ToString("N0"));
+                    GetStackSize(itemDefinition).ToString("N0"));
             }
             
             player.Reply(output.ToString());
@@ -712,7 +712,7 @@ namespace Oxide.Plugins
                     stackable * _config.CategoryStackMultipliers[itemDefinition.category.ToString()]);
             }
 
-            return stackable * _config.GlobalStackMultiplier;
+            return Mathf.RoundToInt(stackable * _config.GlobalStackMultiplier);
         }
 
         private int GetVanillaStackSize(ItemDefinition itemDefinition)

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -655,6 +655,16 @@ namespace Oxide.Plugins
                     return false;
                 }
             }
+            
+            // Return contents
+            if (targetItem.contents?.itemList.Count > 0)
+            {
+                foreach (Item containedItem in targetItem.contents.itemList)
+                {
+                    item.parent.playerOwner.GiveItem(ItemManager.CreateByItemID(containedItem.info.itemid, 
+                        containedItem.amount));
+                }
+            }
 
             if (_config.DisableDupeFixAndLeaveWeaponMagsAlone)
             {
@@ -695,17 +705,7 @@ namespace Oxide.Plugins
                         chainsaw.ammo));
                 }
             }
-            
-            // Return contents
-            if (targetItem.contents?.itemList.Count > 0)
-            {
-                foreach (Item containedItem in targetItem.contents.itemList)
-                {
-                    item.parent.playerOwner.GiveItem(ItemManager.CreateByItemID(containedItem.info.itemid, 
-                        containedItem.amount));
-                }
-            }
-            
+
             return null;
         }
         

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -28,6 +28,34 @@ namespace Oxide.Plugins
             }
             
             EnsureConfigIntegrity();
+
+            AddCovalenceCommand("stacksizecontroller.regendatafile", nameof(RegenerateDataFileCommand),
+                "stacksizecontroller.regendatafile");
+            AddCovalenceCommand("stacksizecontroller.setstack", nameof(SetStackCommand),
+                "stacksizecontroller.setstack");
+            AddCovalenceCommand("stacksizecontroller.setstackcat", nameof(SetStackCategoryCommand),
+                "stacksizecontroller.setstackcat");
+            AddCovalenceCommand("stacksizecontroller.setallstacks", nameof(SetAllStacksCommand),
+                "stacksizecontroller.setallstacks");
+            AddCovalenceCommand("stacksizecontroller.itemsearch", nameof(ItemSearchCommand),
+                "stacksizecontroller.itemsearch");
+            AddCovalenceCommand("stacksizecontroller.listcategories", nameof(ListCategoriesCommand),
+                "stacksizecontroller.listcategories");
+            AddCovalenceCommand("stacksizecontroller.listcategoryitems", nameof(ListCategoryItemsCommand),
+                "stacksizecontroller.listcategoryitems");
+        }
+        
+        private void OnServerInitialized()
+        {
+            _vanillaDefaults =
+                Interface.Oxide.DataFileSystem.ReadObject<Dictionary<string, int>>(nameof(StackSizeController) +
+                    "_vanilla-defaults");
+
+            if (_vanillaDefaults.Count == 0)
+            {
+                // Workaround for exception when hotloading
+                MaintainVanillaStackSizes();
+            }
             
             if (_data.IsUnityNull() || _data.ItemCategories.IsUnityNull())
             {
@@ -71,34 +99,6 @@ namespace Oxide.Plugins
                 {
                     Puts("Datafile backup failed. Migration failed, report to developer.");
                 }
-            }
-
-            AddCovalenceCommand("stacksizecontroller.regendatafile", nameof(RegenerateDataFileCommand),
-                "stacksizecontroller.regendatafile");
-            AddCovalenceCommand("stacksizecontroller.setstack", nameof(SetStackCommand),
-                "stacksizecontroller.setstack");
-            AddCovalenceCommand("stacksizecontroller.setstackcat", nameof(SetStackCategoryCommand),
-                "stacksizecontroller.setstackcat");
-            AddCovalenceCommand("stacksizecontroller.setallstacks", nameof(SetAllStacksCommand),
-                "stacksizecontroller.setallstacks");
-            AddCovalenceCommand("stacksizecontroller.itemsearch", nameof(ItemSearchCommand),
-                "stacksizecontroller.itemsearch");
-            AddCovalenceCommand("stacksizecontroller.listcategories", nameof(ListCategoriesCommand),
-                "stacksizecontroller.listcategories");
-            AddCovalenceCommand("stacksizecontroller.listcategoryitems", nameof(ListCategoryItemsCommand),
-                "stacksizecontroller.listcategoryitems");
-        }
-        
-        private void OnServerInitialized()
-        {
-            _vanillaDefaults =
-                Interface.Oxide.DataFileSystem.ReadObject<Dictionary<string, int>>(nameof(StackSizeController) +
-                    "_vanilla-defaults");
-
-            if (_vanillaDefaults.Count == 0)
-            {
-                // Workaround for exception when hotloading
-                MaintainVanillaStackSizes();
             }
 
             SetStackSizes();

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -135,8 +135,8 @@ namespace Oxide.Plugins
             public bool HidePrefixWithPluginNameInMessages;
 
             public int GlobalStackMultiplier = 1;
-            public Dictionary<string, int> CategoryStackMultipliers = GetCategoriesAndDefaults();
-            public Dictionary<int, int> IndividualItemStackMultipliers = new Dictionary<int, int>();
+            public Dictionary<string, float> CategoryStackMultipliers = GetCategoriesAndDefaults();
+            public Dictionary<int, float> IndividualItemStackMultipliers = new Dictionary<int, float>();
             public Dictionary<int, int> IndividualItemStackHardLimits = new Dictionary<int, int>();
             
             public VersionNumber VersionNumber;
@@ -703,12 +703,13 @@ namespace Oxide.Plugins
             int stackable = _vanillaDefaults[itemDefinition.shortname];
             if (_config.IndividualItemStackMultipliers.ContainsKey(itemDefinition.itemid))
             {
-                return stackable * _config.IndividualItemStackMultipliers[itemDefinition.itemid];
+                return Mathf.RoundToInt(stackable * _config.IndividualItemStackMultipliers[itemDefinition.itemid]);
             }
             
             if (_config.CategoryStackMultipliers.ContainsKey(itemDefinition.category.ToString()))
             {
-                return stackable * _config.CategoryStackMultipliers[itemDefinition.category.ToString()];
+                return Mathf.RoundToInt(
+                    stackable * _config.CategoryStackMultipliers[itemDefinition.category.ToString()]);
             }
 
             return stackable * _config.GlobalStackMultiplier;
@@ -740,9 +741,9 @@ namespace Oxide.Plugins
             }
         }
 
-        private static Dictionary<string, int> GetCategoriesAndDefaults()
+        private static Dictionary<string, float> GetCategoriesAndDefaults()
         {
-            Dictionary<string, int> categoryDefaults = new Dictionary<string, int>();
+            Dictionary<string, float> categoryDefaults = new Dictionary<string, float>();
             
             foreach (string category in Enum.GetNames(typeof(ItemCategory)))
             {

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -103,13 +103,7 @@ namespace Oxide.Plugins
 
             SetStackSizes();
         }
-        
-        private void OnServerSave()
-        {
-            SaveConfig();
-            SaveData();
-        }
-        
+
         private void OnTerrainInitialized()
         {
             Puts("Ensuring VanillaStackSize integrity.");
@@ -376,7 +370,7 @@ namespace Oxide.Plugins
                             ItemId = itemDefinition.itemid,
                             Shortname = itemDefinition.shortname,
                             HasDurability = itemDefinition.condition.enabled,
-                            VanillaStackSize = itemDefinition.stackable,
+                            VanillaStackSize = GetVanillaStackSize(itemDefinition),
                             CustomStackSize = 0
                         });
                 }
@@ -394,7 +388,7 @@ namespace Oxide.Plugins
                 ItemId = itemId,
                 Shortname = itemDefinition.shortname,
                 HasDurability = itemDefinition.condition.enabled,
-                VanillaStackSize = itemDefinition.stackable,
+                VanillaStackSize = GetVanillaStackSize(itemDefinition),
                 CustomStackSize = 0
             };
             
@@ -443,6 +437,8 @@ namespace Oxide.Plugins
                         .Find(itemInfo => itemInfo.ItemId == itemDefinition.itemid);
                 
                     existingItemInfo.VanillaStackSize = GetVanillaStackSize(itemDefinition);
+                    
+                    SaveData();
                 }
             }
             
@@ -450,8 +446,6 @@ namespace Oxide.Plugins
                 vanillaStackSizes);
 
             _vanillaDefaults = new Dictionary<string, int>(vanillaStackSizes);
-
-            SaveData();
         }
 
         #endregion

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -701,11 +701,11 @@ namespace Oxide.Plugins
             {
                 foreach (Item containedItem in targetItem.contents.itemList)
                 {
-                    targetItem.parent.playerOwner.GiveItem(ItemManager.CreateByItemID(containedItem.info.itemid, 
+                    item.parent.playerOwner.GiveItem(ItemManager.CreateByItemID(containedItem.info.itemid, 
                         containedItem.amount));
                 }
             }
-
+            
             return null;
         }
         


### PR DESCRIPTION
## New Features
- Added CategoryStackHardLimits to configuration.
- Multipliers in configuration now allow floats (ex: 2.3, 5.5)
- Configuration settings IndividualItemStackMultipliers and IndividualItemStackHardLimits now accept shortnames as well as item id's.
- Adding stacks through commands now adds shortname instead of item id to the config entry to improve readability.<br>
- Added multiplier to listcategoryitems command.
- Added config option DisableDupeFixAndLeaveWeaponMagsAlone (default false) which disables the weapon ammo unloading, which enables the ammo duplication glitch.

## Fixes
- Fixed vanilla stack size multiplication in main data file. (Harmless but confusing)
- Config and Data file are no longer saved on unload. Should aid in eliminating overwrites to customizations. (Still saves when it's important)
- Configuration integrity checker fixes that likely never affected anyone
- Datafile VanillaStackSize and version number now populate correctly when generating data file (Thanks to RhialtoTheMarvelous for the report)
- Fixed setting stack sizes by command not updating stack sizes unless plugin is reloaded. (Thanks to RhialtoTheMarvelous for the report)
- Potential fix for water stack sizes being messed up (and associated exception when using ChestStacks and similar plugins - probably)
- CustomStackSize in searchs all display correctly now, as the in-game value is set.
- Fix for genetics loss on splitting or stacking plants.
- Fix for NRE exception on CanStackItem when spawning some items as an admin. (Thanks to xTheLastPhoenix for the detailed report)