### PR TITLE
Version 3.3.0

### DIFF
--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -738,12 +738,8 @@ namespace Oxide.Plugins
             }
 
             item.amount -= amount;
-
-            // Maybe not necessary
             newItem.name = item.name;
             newItem.skin = item.skin;
-            newItem._condition = item._condition;
-            newItem._maxCondition = item._maxCondition;
 
             if (item.IsBlueprint())
             {

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Stack Size Controller", "AnExiledGod", "3.2.2")]
+    [Info("Stack Size Controller", "AnExiledGod", "3.3.0")]
     [Description("Allows configuration of most items max stack size.")]
     class StackSizeController : CovalencePlugin
     {
@@ -130,6 +130,7 @@ namespace Oxide.Plugins
         {
             public bool RevertStackSizesToVanillaOnUnload = true;
             public bool AllowStackingItemsWithDurability = true;
+            public bool PreventStackingDifferentSkins;
             public bool HidePrefixWithPluginNameInMessages;
             public bool DisableDupeFixAndLeaveWeaponMagsAlone;
 
@@ -175,7 +176,12 @@ namespace Oxide.Plugins
             {
                 _config.AllowStackingItemsWithDurability = configDefault.AllowStackingItemsWithDurability;
             }
-            
+
+            if (_config.PreventStackingDifferentSkins.IsNull<bool>())
+            {
+                _config.PreventStackingDifferentSkins = configDefault.PreventStackingDifferentSkins;
+            }
+
             if (_config.HidePrefixWithPluginNameInMessages.IsNull<bool>())
             {
                 _config.HidePrefixWithPluginNameInMessages = configDefault.HidePrefixWithPluginNameInMessages;
@@ -629,19 +635,21 @@ namespace Oxide.Plugins
 
         private object CanStackItem(Item item, Item targetItem)
         {
-            if (item.GetOwnerPlayer().IsUnityNull())
+            if (item.GetOwnerPlayer().IsUnityNull() && targetItem.GetOwnerPlayer().IsUnityNull())
             {
                 return null;
             }
             
+            // Duplicating all game checks since we're overriding them by returning true
             if (
                 item == targetItem ||
                 item.info.stackable <= 1 ||
+                targetItem.info.stackable <= 1 ||
                 item.info.itemid != targetItem.info.itemid ||
                 !item.IsValid() ||
-                (item.IsBlueprint() && item.blueprintTarget != targetItem.blueprintTarget) ||
-                (item.hasCondition && (item.condition != item.info.condition.max || 
-                                      targetItem.condition != targetItem.info.condition.max))
+                item.IsBlueprint() && item.blueprintTarget != targetItem.blueprintTarget ||
+                targetItem.hasCondition && (targetItem.condition < targetItem.info.condition.max - 5) ||
+                _config.PreventStackingDifferentSkins && item.skin != targetItem.skin
             )
             {
                 return false;
@@ -665,12 +673,12 @@ namespace Oxide.Plugins
                         containedItem.amount));
                 }
             }
-
+            
             if (_config.DisableDupeFixAndLeaveWeaponMagsAlone)
             {
-                return null;
+                return true;
             }
-                
+            
             BaseProjectile.Magazine itemMag = 
                 targetItem.GetHeldEntity()?.GetComponent<BaseProjectile>()?.primaryMagazine;
             
@@ -679,8 +687,10 @@ namespace Oxide.Plugins
             {
                 if (itemMag.contents > 0)
                 {
-                    item.GetOwnerPlayer().GiveItem(ItemManager.CreateByItemID(itemMag.ammoType.itemid, 
+                    targetItem.GetOwnerPlayer().GiveItem(ItemManager.CreateByItemID(itemMag.ammoType.itemid, 
                         itemMag.contents));
+
+                    itemMag.contents = 0;
                 }
             }
             
@@ -692,6 +702,8 @@ namespace Oxide.Plugins
                 {
                     item.GetOwnerPlayer().GiveItem(ItemManager.CreateByItemID(flameThrower.fuelType.itemid, 
                         flameThrower.ammo));
+
+                    flameThrower.ammo = 0;
                 }
             }
             
@@ -703,17 +715,33 @@ namespace Oxide.Plugins
                 {
                     item.GetOwnerPlayer().GiveItem(ItemManager.CreateByItemID(chainsaw.fuelType.itemid, 
                         chainsaw.ammo));
+
+                    chainsaw.ammo = 0;
                 }
             }
 
-            return null;
+            return true;
         }
         
         private Item OnItemSplit(Item item, int amount)
         {
-            item.amount -= amount;
-            
             Item newItem = ItemManager.CreateByItemID(item.info.itemid, amount, item.skin);
+            BaseProjectile.Magazine newItemMag =
+                newItem.GetHeldEntity()?.GetComponent<BaseProjectile>()?.primaryMagazine;
+
+            if (newItem.contents?.itemList.Count == 0 && 
+                (_config.DisableDupeFixAndLeaveWeaponMagsAlone || (newItem.contents?.itemList.Count == 0 && newItemMag?.contents == 0)))
+            {
+                return null;
+            }
+
+            item.amount -= amount;
+
+            // Maybe not necessary
+            newItem.name = item.name;
+            newItem.skin = item.skin;
+            newItem._condition = item._condition;
+            newItem._maxCondition = item._maxCondition;
 
             if (item.IsBlueprint())
             {
@@ -745,9 +773,6 @@ namespace Oxide.Plugins
             {
                 return newItem;
             }
-            
-            BaseProjectile.Magazine newItemMag =
-                newItem.GetHeldEntity()?.GetComponent<BaseProjectile>()?.primaryMagazine;
 
             // Remove default ammo
             if (newItemMag != null)

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -635,7 +635,9 @@ namespace Oxide.Plugins
 
         private object CanStackItem(Item item, Item targetItem)
         {
-            if (item.GetOwnerPlayer().IsUnityNull() && targetItem.GetOwnerPlayer().IsUnityNull())
+            if (_config.DisableDupeFixAndLeaveWeaponMagsAlone || 
+                (item.GetOwnerPlayer().IsUnityNull() && targetItem.GetOwnerPlayer().IsUnityNull())
+            )
             {
                 return null;
             }
@@ -672,11 +674,6 @@ namespace Oxide.Plugins
                     item.parent.playerOwner.GiveItem(ItemManager.CreateByItemID(containedItem.info.itemid, 
                         containedItem.amount));
                 }
-            }
-            
-            if (_config.DisableDupeFixAndLeaveWeaponMagsAlone)
-            {
-                return true;
             }
             
             BaseProjectile.Magazine itemMag = 
@@ -725,6 +722,11 @@ namespace Oxide.Plugins
         
         private Item OnItemSplit(Item item, int amount)
         {
+            if (_config.DisableDupeFixAndLeaveWeaponMagsAlone)
+            {
+                return null;
+            }
+
             Item newItem = ItemManager.CreateByItemID(item.info.itemid, amount, item.skin);
             BaseProjectile.Magazine newItemMag =
                 newItem.GetHeldEntity()?.GetComponent<BaseProjectile>()?.primaryMagazine;
@@ -768,11 +770,6 @@ namespace Oxide.Plugins
             }
             
             item.MarkDirty();
-            
-            if (_config.DisableDupeFixAndLeaveWeaponMagsAlone)
-            {
-                return newItem;
-            }
 
             // Remove default ammo
             if (newItemMag != null)

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -651,7 +651,7 @@ namespace Oxide.Plugins
                 !item.IsValid() ||
                 item.IsBlueprint() && item.blueprintTarget != targetItem.blueprintTarget ||
                 targetItem.hasCondition && (targetItem.condition < targetItem.info.condition.max - 5) ||
-                _config.PreventStackingDifferentSkins && item.skin != targetItem.skin
+                (_config.PreventStackingDifferentSkins && item.skin != targetItem.skin)
             )
             {
                 return false;

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -684,7 +684,7 @@ namespace Oxide.Plugins
             {
                 if (itemMag.contents > 0)
                 {
-                    targetItem.GetOwnerPlayer().GiveItem(ItemManager.CreateByItemID(itemMag.ammoType.itemid, 
+                    item.GetOwnerPlayer().GiveItem(ItemManager.CreateByItemID(itemMag.ammoType.itemid, 
                         itemMag.contents));
 
                     itemMag.contents = 0;
@@ -716,7 +716,7 @@ namespace Oxide.Plugins
                     chainsaw.ammo = 0;
                 }
             }
-
+            
             return true;
         }
         


### PR DESCRIPTION
- Allowed stacking of items with durability of 95 or higher (technically allowing tiny repairs) to resolve workbench not repairing to max, causing confusion.
- Added configuration option "PreventStackingDifferentSkins" which prevents automatic stacking wiping skins. "false" by default.
- Logic optimizations
- Moved DisableDupeFixAndLeaveWeaponMagsAlone check, which now causes it to ignore weapon mags AND contents (Meaning functionality is untouched) if enabled. This is kind of like enabling "legacy mode". Also allows you to use the garbage skins "fix" (-_-) plugin.
- Fix to splitting items having top item condition, lowering condition of entire stack.
- Fix for CanStackItem NRE when spawning weapons, may fix other instances as well.