### PR TITLE
Release v3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 ## Console Commands
 ### **stacksizecontroller.itemsearch**
+##### **Permission:** `stacksizecontroller.itemsearch` (Only needed if used in-game)
 ##### **Usage:** `stacksizecontroller.itemsearch <full or partial item name>`
 ##### **Parameter #1:** `full or partial item name` Can be any length, however I suggest you use 2, 3 or more characters to avoid potential slowdowns.
 ##### **Usage Example:** `stacksizecontroller.itemsearch pic` (Result pictured below)
@@ -24,6 +25,7 @@
 ----
 
 ### **stacksizecontroller.listcategories**
+##### **Permission:** `stacksizecontroller.listcategories` (Only needed if used in-game)
 ##### **Usage:** `stacksizecontroller.listcategories`
 ##### **Parameters:** `No Parameters`
 ##### **Usage Example:** `stacksizecontroller.listcategories` (Result pictured below)
@@ -33,6 +35,7 @@
 ----
 
 ### **stacksizecontroller.listcategoryitems**
+##### **Permission:** `stacksizecontroller.listcategoryitems` (Only needed if used in-game)
 ##### **Usage:** `stacksizecontroller.listcategoryitems <exact category name>`
 ##### **Parameter #1:** `exact category name` Must be an exact category name. Use stacksizecontroller.listcategories for help.
 ##### **Usage Example:** `stacksizecontroller.listcategoryitems Weapons`
@@ -42,6 +45,7 @@
 ----
 
 ### **stacksizecontroller.setstack**
+##### **Permission:** `stacksizecontroller.setstack` (Only needed if used in-game)
 ##### **Usage:** `stacksizecontroller.setstack <item shortname or id> <stack limit or multiplier>`
 ##### **Parameter #1:** `Shortname or ID` Use stacksizecontroller.itemsearch if you need help.
 ##### **Parameter #2:** `Stack limit or multiplier` Supplying just a number like "2000" sets that as the max stack limit. Supplying a number immediately followed by an x sets a multiplier, like "20x". Entering "20 x" would cause an error.
@@ -52,6 +56,7 @@
 ----
 
 ### **stacksizecontroller.setstackcat**
+##### **Permission:** `stacksizecontroller.setstackcat` (Only needed if used in-game)
 ##### **Usage:** `stacksizecontroller.setstackcat <category name> <stack multiplier>`
 ##### **Parameter #1:** `category name` Use stacksizecontroller.listcategories if you need help. (Not case sensitive)
 ##### **Parameter #2:** `Stack multiplier` Unlike setstack this only accepts a multiplier, it does not require and will error if it's provided with a non-numeric character.
@@ -62,6 +67,7 @@
 ----
 
 ### **stacksizecontroller.setallstacks**
+##### **Permission:** `stacksizecontroller.setallstacks` (Only needed if used in-game)
 ##### **Usage:** `stacksizecontroller.setallstacks <stack multiplier>`
 ##### **Parameter #1:** `Stack multiplier` Unlike setstack this only accepts a multiplier, it does not require and will error if it's provided with a non-numeric character.
 ##### **Usage Example:** `stacksizecontroller.setallstacks 10`
@@ -71,6 +77,7 @@
 ----
 
 ### **stacksizecontroller.regendatafile**
+##### **Permission:** `stacksizecontroller.regendatafile` (Only needed if used in-game)
 ##### **Usage:** `stacksizecontroller.regendatafile`
 ##### **Parameters:** `No Parameters`
 ##### **Usage Example:** `stacksizecontroller.regendatafile`

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -646,7 +646,7 @@ namespace Oxide.Plugins
                 return null;
             }
 
-            Item targetItem = item.parent.GetSlot(targetSlot);
+            Item targetItem = playerLoot.FindContainer(targetContainer).GetSlot(targetSlot);
 
             if (targetItem.IsNull<Item>())
             {
@@ -657,10 +657,11 @@ namespace Oxide.Plugins
             {
                 foreach (Item containedItem in item.contents.itemList)
                 {
-                    item.parent.AddItem(containedItem.info, containedItem.amount, containedItem.skin);
-                }
+                    if (containedItem.info.itemType == ItemContainer.ContentsType.Liquid) { continue; }
 
-                item.contents.Clear();
+                    playerLoot.FindContainer(targetContainer).AddItem(containedItem.info, containedItem.amount, containedItem.skin);
+                    containedItem.Remove();
+                }
             }
 
             // Return contents
@@ -668,10 +669,11 @@ namespace Oxide.Plugins
             {
                 foreach (Item containedItem in targetItem.contents.itemList)
                 {
-                    targetItem.parent.AddItem(containedItem.info, containedItem.amount, containedItem.skin);
-                }
+                    if (containedItem.info.itemType == ItemContainer.ContentsType.Liquid) { continue; }
 
-                targetItem.contents.Clear();
+                    playerLoot.FindContainer(targetContainer).AddItem(containedItem.info, containedItem.amount, containedItem.skin);
+                    containedItem.Remove();
+                }
             }
 
             return null;
@@ -792,6 +794,8 @@ namespace Oxide.Plugins
             {
                 foreach (Item containedItem in item.contents.itemList)
                 {
+                    if (containedItem.info.itemType == ItemContainer.ContentsType.Liquid) { continue; }
+
                     containedItem.Remove();
                 }
             }

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -646,6 +646,13 @@ namespace Oxide.Plugins
                 return null;
             }
 
+            Item targetItem = item.parent.GetSlot(targetSlot);
+
+            if (targetItem.IsNull<Item>())
+            {
+                return null;
+            }
+
             if (item.contents?.itemList.Count > 0)
             {
                 foreach (Item containedItem in item.contents.itemList)
@@ -656,10 +663,8 @@ namespace Oxide.Plugins
                 item.contents.Clear();
             }
 
-            Item targetItem = item.parent.GetSlot(targetSlot);
-
             // Return contents
-            if (targetItem?.contents?.itemList.Count > 0)
+            if (targetItem.info.itemid == item.info.itemid && targetItem.contents?.itemList.Count > 0)
             {
                 foreach (Item containedItem in targetItem.contents.itemList)
                 {

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Stack Size Controller", "AnExiledGod", "3.3.1")]
+    [Info("Stack Size Controller", "AnExiledGod", "3.4.0")]
     [Description("Allows configuration of most items max stack size.")]
     class StackSizeController : CovalencePlugin
     {
@@ -646,6 +646,7 @@ namespace Oxide.Plugins
             }
 
             Item targetItem = playerLoot.FindContainer(targetContainer).GetSlot(targetSlot);
+            ItemContainer container = playerLoot.FindContainer(targetContainer);
 
             if (targetItem.IsNull<Item>())
             {
@@ -658,7 +659,7 @@ namespace Oxide.Plugins
                 {
                     if (containedItem.info.itemType == ItemContainer.ContentsType.Liquid) { continue; }
 
-                    playerLoot.FindContainer(targetContainer).AddItem(containedItem.info, containedItem.amount, containedItem.skin);
+                    container.AddItem(containedItem.info, containedItem.amount, containedItem.skin);
                     containedItem.Remove();
                 }
             }
@@ -670,7 +671,7 @@ namespace Oxide.Plugins
                 {
                     if (containedItem.info.itemType == ItemContainer.ContentsType.Liquid) { continue; }
 
-                    playerLoot.FindContainer(targetContainer).AddItem(containedItem.info, containedItem.amount, containedItem.skin);
+                    container.AddItem(containedItem.info, containedItem.amount, containedItem.skin);
                     containedItem.Remove();
                 }
             }
@@ -683,7 +684,7 @@ namespace Oxide.Plugins
             {
                 if (itemMag.contents > 0)
                 {
-                    playerLoot.FindContainer(targetContainer).AddItem(itemMag.ammoType, itemMag.contents);
+                    container.AddItem(itemMag.ammoType, itemMag.contents);
 
                     itemMag.contents = 0;
                 }
@@ -695,7 +696,7 @@ namespace Oxide.Plugins
 
                 if (flameThrower.ammo > 0)
                 {
-                    playerLoot.FindContainer(targetContainer).AddItem(flameThrower.fuelType, flameThrower.ammo);
+                    container.AddItem(flameThrower.fuelType, flameThrower.ammo);
 
                     flameThrower.ammo = 0;
                 }
@@ -707,7 +708,7 @@ namespace Oxide.Plugins
 
                 if (chainsaw.ammo > 0)
                 {
-                    playerLoot.FindContainer(targetContainer).AddItem(chainsaw.fuelType, chainsaw.ammo);
+                    container.AddItem(chainsaw.fuelType, chainsaw.ammo);
 
                     chainsaw.ammo = 0;
                 }


### PR DESCRIPTION
**NOTICE:** Potentially volatile update, which is why the minor version change, I'm using a new hook which may be a little more viable but I'm not entirely sure how often it's run on a populated server, and may conflict with other plugins using the hook (but really shouldn't.)

- Fixed attachments being removed when moving to an empty slot.
- Fixed more attachment shenanigans.
- Water goes poof more often. (Reminder though that you can't stack things containing water. If you want this limit hardcoded so water won't stack with a config option let me know.)
- Moved CanStackItem functionality into CanMoveItem, and removed CanStackItem functionality. Should increase compatibility and stability. However there may be new plugin conflicts or performance issues potentially, please report anything you notice.