### PR TITLE
Remove heli fuel fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Quick Important Notes
 * Running the plugin once generates items in configuration for IndividualItemStackSize from vanilla defaults. This list is automatically updated when new items are detected, and a notification is put in the console.
-* Multipliers multiply IndividualItemStackSize definitions not vanilla stack size. Individual multipliers take priority over category stack multipliers. 
+* Multipliers multiply IndividualItemStackSize definitions not vanilla stack size. Individual multipliers take priority over category stack multipliers.
 * Datafiles are no longer used. Editing vanilla-defaults does nothing but screw up stack sizes when unloading the plugin.
 * Stacking an item over 2,147,483,647 will cause an error when loaded and will not stack the item at that number. 2,147,483,647 is the max for stack sizes for all stack size plugins as it is a hardcoded limitation of Rust.
 
@@ -150,7 +150,7 @@
     "Electrical": 1.0,
     "Fun": 1.0
   },
-  "IndividualItemStackMultipliers": 
+  "IndividualItemStackMultipliers":
   {
     "-586342290": 10,
     "ammo.pistol": 20
@@ -185,15 +185,3 @@
 - `CategoryStackMultipliers` - Each category will multiply stacks for those items by the defined amount.
 - `IndividualItemStackMultipliers` - Accepts "item_id": multiplier. Use stacksizecontroller.itemsearch to find the item id easily.
 - `IndividualItemStackSize` - Where you define specific stack sizes for each individual item.
-
-## Developer Hooks
-
-#### OnVendorHeliFuelAdjust
-
-- Called when a heli has spawned at a vendor, and this plugin is about to reset its fuel amount to 100
-- Returning `false` will prevent the fuel from being adjusted
-- Returning `null` will result in the default behavior
-
-```csharp
-bool? OnVendorHeliFuelAdjust(MiniCopter heli)
-```

--- a/StackSizeController.cs
+++ b/StackSizeController.cs
@@ -1,11 +1,10 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Oxide.Core;
 using Oxide.Core.Libraries;
 using Oxide.Core.Libraries.Covalence;
-using Oxide.Core.Plugins;
 using UnityEngine;
 
 namespace Oxide.Plugins
@@ -14,9 +13,6 @@ namespace Oxide.Plugins
     [Description("Allows configuration of most items max stack size.")]
     class StackSizeController : CovalencePlugin
     {
-        [PluginReference]
-        Plugin AirFuel, GetToDaChoppa, VehicleVendorOptions;
-
         private const string _vanillaDefaultsUri = "https://raw.githubusercontent.com/AnExiledDev/StackSizeController/master/vanilla-defaults.json";
 
         private Configuration _config;
@@ -263,41 +259,6 @@ namespace Oxide.Plugins
         #endregion
 
         #region Hooks
-
-        // Credit to WhiteThunder- https://github.com/AnExiledDev/StackSizeController/pull/7
-        // Fix initial fuel amount for vendor-spawned helis since they use 20% of max stack size of low grade.
-        private void OnEntitySpawned(MiniCopter heli)
-        {
-            // Ignore if a known plugin is loaded that adjusts heli fuel.
-            if (AirFuel != null || GetToDaChoppa != null || VehicleVendorOptions != null)
-                return;
-
-            // Must delay for vendor-spawned helis since the creatorEntity is set after spawn.
-            NextTick(() =>
-            {
-                if (heli == null
-                    // Make sure it's a vendor-spawned heli.
-                    || !heli.IsSafe()
-                    // Make sure the game hasn't changed unexpectedly.
-                    || heli.StartingFuelUnits() != -1)
-                    return;
-
-                var fuelItem = heli.GetFuelSystem()?.GetFuelItem();
-                if (fuelItem == null
-                    // Ignore other types of fuel since they will have been placed by mods.
-                    || fuelItem.info.shortname != "lowgradefuel"
-                    // Ignore if the fuel amount is unexpected, since a mod likely adjusted it.
-                    || fuelItem.amount != fuelItem.info.stackable / 5)
-                    return;
-
-                var hookResult = Interface.CallHook("OnVendorHeliFuelAdjust", heli);
-                if (hookResult is bool && (bool)hookResult == false)
-                    return;
-
-                fuelItem.amount = 100;
-                fuelItem.MarkDirty();
-            });
-        }
 
         int OnMaxStackable(Item item)
         {


### PR DESCRIPTION
Purchased helis now always start with 100 fuel in vanilla
https://commits.facepunch.com/412359

My editor automatically applied a few code whitespace issues.